### PR TITLE
Fix crash when SMART_BANNER is used.

### DIFF
--- a/src/android/com/google/cordova/plugin/AdMobPlugin.java
+++ b/src/android/com/google/cordova/plugin/AdMobPlugin.java
@@ -346,10 +346,24 @@ public class AdMobPlugin extends CordovaPlugin {
 	}
 	
 	private void executeKillAd(CallbackContext callbackContext) {
-			adView.destroy();
-			adView = null;
-			// Notify the plugin.
-			callbackContext.success();
+	        final Runnable runnable = new Runnable() {
+            		public void run() {
+                		if (adView == null) {
+                    		// Notify the plugin.
+                    			callbackContext.error("AdView is null.  Did you call createBannerView or already destroy it?");
+                		} else {
+                    			LinearLayoutSoftKeyboardDetect parentView = (LinearLayoutSoftKeyboardDetect) webView
+							.getParent();
+		                    parentView.removeView(adView);
+		                    adView.removeAllViews();
+		                    adView.destroy();
+		                    adView = null;
+		                    callbackContext.success();
+		                }
+	            	}
+	        };
+
+        	this.cordova.getActivity().runOnUiThread(runnable);
 	}
 
 	/**


### PR DESCRIPTION
Requesting a SMART_BANNER in android causes a crash because the adSize isn't actually set yet.  See https://groups.google.com/forum/#!topic/google-admob-ads-sdk/lU9a86gKhBU . This simply log's the size before AdSize is requested...
