### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ http://docs.phonegap.com/en/edge/guide_cli_index.md.html#The%20Command-line%20In
 How to install plugin whith phonegap CLI : 
 > phonegap local plugin add https://github.com/aliokan/cordova-plugin-admob
 
-##Implementation:
+## Implementation:
 
 There are two calls needed to get AdMob Ads:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
